### PR TITLE
New features (profiles, opt-in triggers)

### DIFF
--- a/steem-exif-spider-bot/config/index.js
+++ b/steem-exif-spider-bot/config/index.js
@@ -1,5 +1,20 @@
 module.exports = {
     user: process.env.STEEM_NAME,
     wif: process.env.STEEM_WIF,
-    weight: parseInt(process.env.VOTING_WEIGHT)
+    weight: parseInt(process.env.VOTING_WEIGHT), 
+    blacklist: [
+        "emwalker",
+        "tomlabe",
+        "stranded", 
+        "soma909", 
+        "mammasitta",
+        "pfunk", 
+        "nwtdarren", 
+        "betterthanhome",
+        "karenb54",
+        "teddy2",
+        "spreadfire1",
+        "ninahaskin",
+        "wdoutjah"
+    ]
 }

--- a/steem-exif-spider-bot/helpers/bot/comment.js
+++ b/steem-exif-spider-bot/helpers/bot/comment.js
@@ -27,41 +27,41 @@ function execute(comments) {
         }
 
         Promise.each(tags, (tag, index, length) => {
-            if (tag.name == 'URL') {
+            if (tag.name.toLowerCase() == 'url') {
                 context.url = tag.description
                 tags[index] = {}
             }
         })
         .then(() => {
-        return loadTemplate(path.join(__dirname, '..', 'templates', "exif.hb"))
-            .then((template) => {
-                var templateSpec = Handlebars.compile(template)
-                return templateSpec(context)
-            })
-            .then((message) => {
-                var new_permlink = 're-' + author 
-                    + '-' + permlink 
-                    + '-' + new Date().toISOString().replace(/[^a-zA-Z0-9]+/g, '').toLowerCase();
-                console.log("Commenting on ", author, permlink)
+            return loadTemplate(path.join(__dirname, '..', 'templates', "exif.hb"))
+                .then((template) => {
+                    var templateSpec = Handlebars.compile(template)
+                    return templateSpec(context)
+                })
+                .then((message) => {
+                    var new_permlink = 're-' + author 
+                        + '-' + permlink 
+                        + '-' + new Date().toISOString().replace(/[^a-zA-Z0-9]+/g, '').toLowerCase();
+                    console.log("Commenting on ", author, permlink)
 
-                return steem.broadcast.commentAsync(
-                    wif,
-                    author, // Leave parent author empty
-                    permlink, // Main tag
-                    user, // Author
-                    new_permlink, // Permlink
-                    new_permlink,
-                    message, // Body
-                    { tags: [], app: "steemit-exif-spider-bot/0.1.0" }
-                ).then((results) => {
-                    console.log(results)
-                    return results
-                })
-                .catch((err) => {
-                    console.log("Error ", err.message)
+                    return steem.broadcast.commentAsync(
+                        wif,
+                        author, // Leave parent author empty
+                        permlink, // Main tag
+                        user, // Author
+                        new_permlink, // Permlink
+                        new_permlink,
+                        message, // Body
+                        { tags: [], app: "steemit-exif-spider-bot/0.1.0" }
+                    ).then((results) => {
+                        console.log(results)
+                        return results
+                    })
+                    .catch((err) => {
+                        console.log("Error ", err.message)
+                    })
                 })
             })
-        })
     })
 }
 

--- a/steem-exif-spider-bot/helpers/bot/comment.js
+++ b/steem-exif-spider-bot/helpers/bot/comment.js
@@ -15,44 +15,54 @@ function loadTemplate(template) {
 
 
 function execute(comments) {
+    schedule.scheduleJob(MINUTE, function() {
 
-    if (comments.length() < 1) {
-        return {};
-    }
+        if (comments.length() < 1) {
+            return {};
+        }
 
-    const { author, permlink } = comments.shift();
+        const { author, permlink, tags } = comments.shift();
+        var context = {
+            tags: tags
+        }
 
-    var context = {
-    }
-
-    return loadTemplate(path.join(__dirname, '..', 'templates', "exif.hb"))
-        .then((template) => {
-            var templateSpec = Handlebars.compile(template)
-            return templateSpec(context)
+        Promise.each(tags, (tag, index, length) => {
+            if (tag.name == 'URL') {
+                context.url = tag.description
+                tags[index] = {}
+            }
         })
-        .then((message) => {
-            var new_permlink = 're-' + author 
-                + '-' + permlink 
-                + '-' + new Date().toISOString().replace(/[^a-zA-Z0-9]+/g, '').toLowerCase();
-            console.log("Commenting on ", author, permlink, type)
-
-            return steem.broadcast.commentAsync(
-                wif,
-                author, // Leave parent author empty
-                permlink, // Main tag
-                user, // Author
-                new_permlink, // Permlink
-                new_permlink,
-                message, // Body
-                { tags: [], app: "steemit-exif-spider-bot/0.1.0" }
-            ).then((results) => {
-                console.log(results)
-                return results
+        .then(() => {
+        return loadTemplate(path.join(__dirname, '..', 'templates', "exif.hb"))
+            .then((template) => {
+                var templateSpec = Handlebars.compile(template)
+                return templateSpec(context)
             })
-            .catch((err) => {
-                console.log("Error ", err.message)
+            .then((message) => {
+                var new_permlink = 're-' + author 
+                    + '-' + permlink 
+                    + '-' + new Date().toISOString().replace(/[^a-zA-Z0-9]+/g, '').toLowerCase();
+                console.log("Commenting on ", author, permlink)
+
+                return steem.broadcast.commentAsync(
+                    wif,
+                    author, // Leave parent author empty
+                    permlink, // Main tag
+                    user, // Author
+                    new_permlink, // Permlink
+                    new_permlink,
+                    message, // Body
+                    { tags: [], app: "steemit-exif-spider-bot/0.1.0" }
+                ).then((results) => {
+                    console.log(results)
+                    return results
+                })
+                .catch((err) => {
+                    console.log("Error ", err.message)
+                })
             })
         })
+    })
 }
 
 module.exports = {

--- a/steem-exif-spider-bot/helpers/bot/exif.js
+++ b/steem-exif-spider-bot/helpers/bot/exif.js
@@ -66,6 +66,10 @@ const exif_profiles = {
                 "shutterspeedvalue" 
             ].includes(key.toLowerCase())
     }, 
+    copyright: (key) => {
+        return (key.indexOf("opyright") > -1
+                || key.indexOf("reator") > -1)
+    },
     the_works: (key) => { return true}
 }
 

--- a/steem-exif-spider-bot/helpers/bot/exif.js
+++ b/steem-exif-spider-bot/helpers/bot/exif.js
@@ -20,9 +20,132 @@ module.exports = {
 let VOTING = {}
 let COMMENTS = {}
 
+const exif_profiles = {
+    basics: (key) => {
+        return [
+                "make",
+                "model",
+                "pixelxdimension",
+                "pixelydimension",
+                "focallength",
+                "lightsource",
+                "flash",
+                "fnumber",
+                "exposuretime",
+                "datetime",
+                "isospeedratings",
+                "exposurebiasvalue",
+                "exposuremode",
+                "whitebalance",
+                "meteringmode",
+                "software",
+                "exposureprogram",
+                "datetimeoriginal",
+                "shutterspeedvalue",
+                "aperturevalue",
+                "brightnessvalue",
+                "focallengthin35mmfilm",
+                "creatortool"       
+            ].includes(key.toLowerCase())
+    }, 
+    minimal: (key) => {
+        return [
+                "make",
+                "model",
+                "focallength",
+                "lightsource",
+                "flash",
+                "fnumber",
+                "exposuretime",
+                "datetime",
+                "isospeedratings",
+                "exposurebiasvalue",
+                "whitebalance",
+                "meteringmode",
+                "datetimeoriginal",
+                "shutterspeedvalue" 
+            ].includes(key.toLowerCase())
+    }, 
+    the_works: (key) => { return true}
+}
+
 function loadTemplate(template) {
     return fs.readFileAsync(template, 'utf8')
 }
+
+function get_profiles_from(text) {
+    return text.replace("@" + user, "").replace(",", " ").split(" ")
+        .filter((profile) => profile && profile.trim() != "")
+        .map((profile) => { return profile.toLowerCase()});
+}
+
+function profile_check(profiles, key) {
+    // Default profile
+    if (profiles.length < 1) {
+        return exif_profiles.basics(key)
+    }
+
+    if (profiles.includes(key.toLowerCase())) {
+        return true
+    }
+
+    // all profiles exist
+    const profile = profiles.shift();
+    if (Object.keys(exif_profiles).includes(profiles)) {
+        return exif_profiles[profile](key)
+    }
+
+    return false
+}
+
+function handle_exif(comment, profiles, images) {
+    console.log("Handling exif for ", images)
+    return Promise.map(images, (image, index, length) => {
+        const buffers = [];
+        return got(image, {encoding: null })
+            .then((response) => {
+                const tags = ExifReader.load(response.body);
+                tags.URL = { description: image, value: image }
+                return tags;
+            })
+            .catch((error) => {
+                if (error.message == "No Exif data") {
+                    console.log("error ", error)
+                }
+                else {
+                    console.log("error ", error)
+                }
+            });
+    })
+    .filter((tags) => tags ? true : false)
+    .each((input) => {
+        const tags = []
+        let URL = ""
+
+        if (!Object.keys(input).includes("Make")) {
+            return 
+        }
+
+        for (let key in input) {
+            const value = input[key];
+            if (key == "URL") {
+                URL = value
+                tags.push({ name: key, value: value.value, description: value.description })                
+            }
+
+            if (profile_check(profiles, key)) {            
+                tags.push({ name: key, value: value.value, description: value.description })
+            }
+        }
+        console.log("Pushing tags for ", URL)
+        reply(comment, tags)
+    })
+    .catch((error) => {
+        console.log("Error ", error)
+    });
+
+}
+
 
 function processComment(comment) {
     return steem.api.getContentAsync(comment.author, comment.permlink)
@@ -33,71 +156,52 @@ function processComment(comment) {
             return {};
         })
         .then((metadata) => {
-            if ((metadata.tags && (metadata.tags.includes("photofeed")
-                                    || metadata.tags.includes("photography")))
-                && metadata.image && metadata.image.length > 0) {
-                return metadata.image;
+            if (metadata.users && metadata.users.includes(user)) {
+                console.log("Found @exifr request")
+
+                if (comment.parent_author == "") {
+                    metadata.exif_profiles = get_profiles_from(comment.body)
+                    return metadata;
+                }
+                
+                return steem.api.getContentAsync(comment.parent_author, comment.parent_permlink)
+                    .then((content) => {
+                        if (content.json_metadata && content.json_metadata != '') {
+                            const metadata = JSON.parse(content.json_metadata);
+                            metadata.exif_profiles = get_profiles_from(comment.body)
+                            return metadata;
+                        }
+                        return {};
+                    })
+            }
+            return {}
+        })
+        .then((metadata) => {
+            if (metadata.image && metadata.image.length > 0) {
+                return [metadata.exif_profiles, metadata.image]
             }
             return [];
         })
-        .map((image) => {
-            if (image.indexOf(".jpg") > -1 || image.indexOf(".JPG") > -1) {
-                const buffers = [];
-                return got(image, {encoding: null })
-                    .then((response) => {
-                        const tags = ExifReader.load(response.body);
-                        tags.URL = { description: image, value: image }
-                        return tags;
-                    })
-                    .catch((error) => {
-                        if (error.message == "No Exif data") {
-
-                        }
-                        else {
-                            console.log("error ", error)
-                        }
-                    });
+        .spread((profiles, images) => {
+            if (images) {
+                return handle_exif(comment, profiles, images);
             }
+            return {}
         })
-        .filter((tags) => tags ? true : false)
-        .each((input) => {
-            const tags = []
-            let URL = ""
-            for (let key in input) {
-
-                const value = input[key];
-                if (key == "URL") {
-                    URL = input[key]
-                }
-
-                if (key != "MakerNote"
-                    && key.indexOf("undefined") < 0
-                    && key.indexOf("omment") < 0
-                    && key.indexOf("ersion") < 0) {
-                    tags.push({ name: key, value: value.value, description: value.description })
-                }
-            }
-            if (tags.length > 5) {
-                console.log("Pushing tags for ", URL)
-                reply(comment, tags)
-            }
-        })
-        .catch((error) => {
-            console.log("Error ", error)
-        });
 }
 
 function reply(comment, tags) {
-    const context = {
-        poster: comment.author,
-        tags: tags
+    const target = { author: comment.author, permlink: comment.permlink }
+    if (comment.parent_author != "") {
+        target.author = comment.parent_author
+        target.permlink = comment.parent_permlink
     }
 
     return new Promise((resolve, reject) => {
         // console.log("Pushing comment for ", { author: comment.author, permlink: comment.permlink})
-        COMMENTS.push({ author: comment.author, permlink: comment.permlink, tags: tags })
+        COMMENTS.push({ author: target.author, permlink: target.permlink, tags: tags })
 
-        resolve([ comment.author, comment.permlink])
+        resolve([ target.author, target.permlink])
     })
     .spread((author, permlink) => {
         console.log("Pushing vote for ", { author: author, permlink: permlink, weight: weight })
@@ -123,9 +227,7 @@ function execute(voting, comments) {
         .spread((operation_name, operation) => {
             switch(operation_name) {
                 case "comment":
-                    if (operation.parent_author == '') {
-                        return processComment(operation);
-                    }
+                    return processComment(operation);
                 break;
                 default:
             }

--- a/steem-exif-spider-bot/helpers/bot/exif.js
+++ b/steem-exif-spider-bot/helpers/bot/exif.js
@@ -47,7 +47,9 @@ function processComment(comment) {
                         return ExifReader.load(response.body);
                     })
                     .catch((error) => {
-                        console.log("Error ", error);
+                        if (err.message == "No Exif data") {
+
+                        }
                     });
             }
         })

--- a/steem-exif-spider-bot/helpers/templates/exif.hb
+++ b/steem-exif-spider-bot/helpers/templates/exif.hb
@@ -1,7 +1,11 @@
 EXIF Data for your Photo
 
+> <img src="{{url}}" width="25" />
+
 |Tag Name|Value|Description|
 |--------|-----|-----------|
 {{#each tags}}
+{{#if name}}
 |{{name}}|{{value}}|{{description}}|
+{{/if}}
 {{/each}}


### PR DESCRIPTION
## Profiles

There are now profiles/presets that can be used to configure what fields to display. The default is **basics** which is a moderate amount of information that pertains to photography. Other profiles are:
* **copyright** shows only copyright related information
* **the_works** indiscriminately dump all exif information (use at your own discretion)
* **minimal** Even more diminutive data

### Custom datasets

It's also possible to bypass profiles and explicitly define which fields you wish to show.

## Opt-in Triggers

Rather applying data to all photos in the blockchain by tag, follow an opt-in only model where users must explicitly request this feature to be applied to their posts.